### PR TITLE
Replacing the calls to ERFA by pure Julia functions for eraUtctai

### DIFF
--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -234,7 +234,7 @@ end
 # TAI <-> UTC
 function rescale(::Type{TAIEpoch}, ep::UTCEpoch)
     jd1, jd2 = julian1(ep), julian2(ep)
-    date, date1 = ERFA.utctai(jd1, jd2)
+    date, date1 = utctai(jd1, jd2)
     TAIEpoch(date, date1)
 end
 

--- a/src/conversions.jl
+++ b/src/conversions.jl
@@ -5,6 +5,32 @@ export rescale
 
 using ..LeapSeconds
 
+"""
+   utctai(jd1, jd2)
+
+Transform a two-part Julia date from `UTC` to `TAI`.
+
+# Example
+
+```jldoctest
+julia> utc  = Epoch{UTC}(2.4578265e6, 0.30477440993249416)
+2017-03-14T07:18:52.509 UTC
+julia> AstronomicalTime.Epochs.utctai(utc.jd1, utc.jd2)
+(2.4578265e6, 0.3052026506732349)
+```
+"""
+function utctai(jd1, jd2)
+    ls = leapseconds(jd1 + jd2)
+    dtat = ls/SECONDS_PER_DAY;
+    if jd1 > jd2
+        jd1 = jd1
+        jd2 += dtat
+    else
+        jd1 += dtat
+        jd2 = jd2
+    end
+    jd1, jd2
+end
 
 """
    taiutc(jd1, jd2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -151,6 +151,7 @@ AstronomicalTime.update()
     @testset "PortedFunctions" begin
 
         tai = TAIEpoch(2000, 1, 1, 12, 0, 0.0)
+        utc = UTCEpoch(2000, 1, 1, 12, 0, 0.0)
         ut1 = UT1Epoch(2000, 1, 1, 12, 0, 0.0)
         tcg = TCGEpoch(2000, 1, 1, 12, 0, 0.0)
         tt = TTEpoch(2000, 1, 1, 12, 0, 0.0)
@@ -170,6 +171,8 @@ AstronomicalTime.update()
         @test AstronomicalTime.Epochs.tttcg(julian2(tt), julian1(tt)) == ERFA.tttcg(julian2(tt), julian1(tt))
         @test AstronomicalTime.Epochs.taiutc(julian1(tai), julian2(tai)) == ERFA.taiutc(julian1(tai), julian2(tai))
         @test AstronomicalTime.Epochs.taiutc(julian2(tai), julian1(tai)) == ERFA.taiutc(julian2(tai), julian1(tai))
+        @test AstronomicalTime.Epochs.utctai(julian1(utc), julian2(utc)) == ERFA.utctai(julian1(utc), julian2(utc))
+        @test AstronomicalTime.Epochs.utctai(julian2(utc), julian1(utc)) == ERFA.utctai(julian2(utc), julian1(utc))
     end
     @testset "Leap Seconds" begin
         @test leapseconds(TTEpoch(1959,1,1)) == 0


### PR DESCRIPTION
Replacing the calls to ERFA by pure Julia functions for eraTaiutc using LeapSeconds.jl as the Offset Time is not Constant. Tests and Docstrings are added